### PR TITLE
Draft: Added mutex to allow synchronisation between threads.

### DIFF
--- a/src/LuaMultiThreaded2.cpp
+++ b/src/LuaMultiThreaded2.cpp
@@ -115,6 +115,50 @@ extern "C" static int mutexDoWhileLocked(LuaState * aState)
 
 
 
+/** Locks the provided mutex. */
+extern "C" static int mutexLock(LuaState * aState) 
+{
+	auto mutexObj = reinterpret_cast<std::mutex**>(luaL_checkudata(aState, 1, MUTEX_METATABLE_NAME));
+	if (mutexObj == nullptr)
+	{
+		luaL_argerror(aState, 0, "'mutex' expected");
+		return 0;
+	}
+	if (*mutexObj == nullptr)
+	{
+		luaL_argerror(aState, 0, "'mutex' expected");
+		return 0;
+	}
+	(*mutexObj)->lock();
+	return 0;
+}
+
+
+
+
+
+/** Unlocks the provided mutex. */
+extern "C" static int mutexUnlock(LuaState * aState) 
+{
+	auto mutexObj = reinterpret_cast<std::mutex**>(luaL_checkudata(aState, 1, MUTEX_METATABLE_NAME));
+	if (mutexObj == nullptr)
+	{
+		luaL_argerror(aState, 0, "'mutex' expected");
+		return 0;
+	}
+	if (*mutexObj == nullptr)
+	{
+		luaL_argerror(aState, 0, "'mutex' expected");
+		return 0;
+	}
+	(*mutexObj)->unlock();
+	return 0;
+}
+
+
+
+
+
 extern "C" static int threadNew(LuaState * aState)
 {
 	static std::recursive_mutex mtx;
@@ -298,6 +342,8 @@ static const luaL_Reg mutexFuncs[] =
 static const luaL_Reg mutexObjFuncs[] =
 {
 	{"dowhilelocked", &mutexDoWhileLocked},
+	{"lock", &mutexLock},
+	{"unlock", &mutexUnlock},
 	{NULL, NULL}
 };
 

--- a/src/LuaMultiThreaded2.cpp
+++ b/src/LuaMultiThreaded2.cpp
@@ -68,13 +68,14 @@ extern "C" int errorHandler(LuaState * L)
 
 
 
-
+/** Creates a new mutex object.
+Returns: The mutex object with the functions in mutexObjFuncs as methods in it's metatable. */
 extern "C" static int mutexNew(LuaState * aState)
 {
 	lua_pushcfunction(aState, errorHandler);
 
 	// Push the (currently empty) mutex object to the Lua side
-	auto mutexObj = reinterpret_cast<std::mutex**>(lua_newuserdata(aState, sizeof(std::mutex**)));
+	auto mutexObj = reinterpret_cast<std::mutex **>(lua_newuserdata(aState, sizeof(std::mutex **)));
 	luaL_setmetatable(aState, MUTEX_METATABLE_NAME);
 
 	// Create the new mutex:
@@ -86,12 +87,10 @@ extern "C" static int mutexNew(LuaState * aState)
 
 
 
-
-
 /** Executes the provided function while the mutex is locked. */
 extern "C" static int mutexDoWhileLocked(LuaState * aState)
 {
-	auto mutexObj = reinterpret_cast<std::mutex**>(luaL_checkudata(aState, 1, MUTEX_METATABLE_NAME));
+	auto mutexObj = reinterpret_cast<std::mutex **>(luaL_checkudata(aState, 1, MUTEX_METATABLE_NAME));
 	if (mutexObj == nullptr)
 	{
 		luaL_argerror(aState, 0, "'mutex' expected");
@@ -99,7 +98,7 @@ extern "C" static int mutexDoWhileLocked(LuaState * aState)
 	}
 	if (*mutexObj == nullptr) 
 	{
-		luaL_argerror(aState, 0, "'mutex' expected");
+		luaL_argerror(aState, 0, "Internal error: 'mutex' object is invalid");
 		return 0;
 	}
 	(*mutexObj)->lock();
@@ -118,7 +117,7 @@ extern "C" static int mutexDoWhileLocked(LuaState * aState)
 /** Locks the provided mutex. */
 extern "C" static int mutexLock(LuaState * aState) 
 {
-	auto mutexObj = reinterpret_cast<std::mutex**>(luaL_checkudata(aState, 1, MUTEX_METATABLE_NAME));
+	auto mutexObj = reinterpret_cast<std::mutex **>(luaL_checkudata(aState, 1, MUTEX_METATABLE_NAME));
 	if (mutexObj == nullptr)
 	{
 		luaL_argerror(aState, 0, "'mutex' expected");
@@ -126,7 +125,7 @@ extern "C" static int mutexLock(LuaState * aState)
 	}
 	if (*mutexObj == nullptr)
 	{
-		luaL_argerror(aState, 0, "'mutex' expected");
+		luaL_argerror(aState, 0, "Internal error: 'mutex' object is invalid");
 		return 0;
 	}
 	(*mutexObj)->lock();
@@ -140,7 +139,7 @@ extern "C" static int mutexLock(LuaState * aState)
 /** Unlocks the provided mutex. */
 extern "C" static int mutexUnlock(LuaState * aState) 
 {
-	auto mutexObj = reinterpret_cast<std::mutex**>(luaL_checkudata(aState, 1, MUTEX_METATABLE_NAME));
+	auto mutexObj = reinterpret_cast<std::mutex **>(luaL_checkudata(aState, 1, MUTEX_METATABLE_NAME));
 	if (mutexObj == nullptr)
 	{
 		luaL_argerror(aState, 0, "'mutex' expected");
@@ -148,7 +147,7 @@ extern "C" static int mutexUnlock(LuaState * aState)
 	}
 	if (*mutexObj == nullptr)
 	{
-		luaL_argerror(aState, 0, "'mutex' expected");
+		luaL_argerror(aState, 0, "Internal error: 'mutex' object is invalid");
 		return 0;
 	}
 	(*mutexObj)->unlock();
@@ -159,6 +158,9 @@ extern "C" static int mutexUnlock(LuaState * aState)
 
 
 
+/** Starts a new thread and runs the provided Lua function on it. 
+Parameter: The Lua callback which will be called on the new thread.
+Returns: The thread object with the functions in threadObjFuncs as methods in it's metatable. */
 extern "C" static int threadNew(LuaState * aState)
 {
 	static std::recursive_mutex mtx;

--- a/tests/RaceConditionMutex.lua
+++ b/tests/RaceConditionMutex.lua
@@ -1,0 +1,40 @@
+-- Tests a race condition. Identical to RaceCondition.lua except it uses a mutex to prevent the race condition
+
+local thread = require("thread")
+
+--- The global variable being read and written
+local a = 0
+
+--- The number of iterations of the inner loop
+local MAX_COUNTER = 100000
+
+-- The mutex to allow the threads to write to the global variable.
+local mtx = mutex.new();
+
+
+
+--- The thread function, executed in two threads in parallel
+local function thrFunc()
+	for i = 1, MAX_COUNTER do
+		mtx:lock(function()
+			a = a + 1
+		end)
+	end
+end
+
+
+
+
+
+local thread1 = thread.new(thrFunc)
+local thread2 = thread.new(thrFunc)
+
+thread1:join()
+thread2:join()
+
+if (a == 2 * MAX_COUNTER) then
+	print("No race condition detected")
+else
+	print("Race condition detected:")
+	print("a = " .. tostring(a) .. "(expected " .. 2 * MAX_COUNTER .. ")")
+end

--- a/tests/RaceConditionMutex.lua
+++ b/tests/RaceConditionMutex.lua
@@ -16,7 +16,7 @@ local mtx = mutex.new();
 --- The thread function, executed in two threads in parallel
 local function thrFunc()
 	for i = 1, MAX_COUNTER do
-		mtx:lock(function()
+		mtx:dowhilelocked(function()
 			a = a + 1
 		end)
 	end

--- a/tests/RaceConditionMutex.lua
+++ b/tests/RaceConditionMutex.lua
@@ -17,7 +17,7 @@ local mtx = mutex.new();
 local function thrFunc()
 	for i = 1, MAX_COUNTER do
 		mtx:dowhilelocked(function()
-			a = a + 1
+			a = a + 1	
 		end)
 	end
 end
@@ -32,9 +32,5 @@ local thread2 = thread.new(thrFunc)
 thread1:join()
 thread2:join()
 
-if (a == 2 * MAX_COUNTER) then
-	print("No race condition detected")
-else
-	print("Race condition detected:")
-	print("a = " .. tostring(a) .. "(expected " .. 2 * MAX_COUNTER .. ")")
-end
+assert(a == 2 * MAX_COUNTER, "Race condition detected: a = " .. tostring(a) .. "(expected " .. 2 * MAX_COUNTER .. ")");
+


### PR DESCRIPTION
Thought I'd post this as a draft as I'm not really sure if this is the way we want to implement mutexes.

You can  use mutexes in the following way:
```lua
local mtx = mutex.new();

mtx:lock(function()
    -- Do stuff while the mutex is locked.
end)
```

I was thinking about just exporting the lock and unlock methods, but this allows the mutex to be unlocked if the code gives an error. On the other hand that might cause even more issues down the line.