### PR TITLE
Mutex gc

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,6 +43,7 @@ set(TESTS
 	CurrentThreadId.lua
 	HelloThread.lua
 	HelloWorld.lua
+	MutexGc.lua
 	NestedThreadCreation.lua
 	RaceCondition.lua
 	RaceConditionMutex.lua

--- a/src/LuaMultiThreaded2.cpp
+++ b/src/LuaMultiThreaded2.cpp
@@ -158,6 +158,27 @@ extern "C" static int mutexObjUnlock(LuaState * aState)
 
 
 
+/** Called when the Lua side GC's the mutex object. */
+extern "C" static int mutexObjGc(LuaState * aState)
+{
+	auto mutexObj = reinterpret_cast<std::mutex **>(luaL_checkudata(aState, 1, MUTEX_METATABLE_NAME));
+	if (mutexObj == nullptr)
+	{
+		luaL_argerror(aState, 0, "'mutex' expected");
+		return 0;
+	}
+	if (*mutexObj == nullptr)
+	{
+		return 0;
+	}
+	*mutexObj = nullptr;
+	return 0;
+}
+
+
+
+
+
 /** Starts a new thread and runs the provided Lua function on it. 
 Parameter: The Lua callback which will be called on the new thread.
 Returns: The thread object with the functions in threadObjFuncs as methods in it's metatable. */
@@ -351,6 +372,7 @@ static const luaL_Reg mutexObjFuncs[] =
 	{"dowhilelocked", &mutexObjDoWhileLocked},
 	{"lock",          &mutexObjLock},
 	{"unlock",        &mutexObjUnlock},
+	{"__gc",          &mutexObjGc},
 	{nullptr,         nullptr}
 };
 

--- a/tests/MutexGc.lua
+++ b/tests/MutexGc.lua
@@ -1,0 +1,15 @@
+-- Forces a mutex object to be garbage collected by Lua.
+
+local thread = require("thread")
+
+-- Create a new mutex.
+local mtx = mutex.new();
+
+-- Immediately set the mutex to nil
+mtx = nil;
+
+-- Force the garbage collector to collect everything.
+-- Unfortunately there is no way to check if the value was properly destroyed from Lua
+-- but it can be used to see if a breakpoint inside the __gc function is reached.
+-- If the __gc function crashes it can be detected here as well.
+collectgarbage("collect");


### PR DESCRIPTION
Fixes #7 

I wasn't sure if the mutex should unlock if it's garbage collected. I did try to see if you can call unlock even if it wasn't locked but this causes a crash (maybe we should also check for this in mutex:unlock?)


It might be possible to fix this using mutex->try_lock()
```cpp
if ((*mutexObj)->try_lock()) 
{
    (*mutexObj)->unlock();
}
``` 