### PR TITLE
Added the MultiThreadedGC test that crashes.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,6 +43,7 @@ set(TESTS
 	CurrentThreadId.lua
 	HelloThread.lua
 	HelloWorld.lua
+	MultiThreadedGC.lua
 	MutexGc.lua
 	NestedThreadCreation.lua
 	RaceCondition.lua

--- a/tests/MultiThreadedGC.lua
+++ b/tests/MultiThreadedGC.lua
@@ -1,0 +1,43 @@
+-- Tests running the garbage collector in parallel with creating a lot of local temporary objects
+
+local thread = require("thread")
+
+
+
+
+--- Creates lots of local temporary objects that can be GC-ed
+local function thrCreateObjects()
+	for j = 1, 10 do
+		for i = 1, 100 do
+			table.concat({"a", i}, ", ")  -- Create a table, then a string, and lose all references to them immediately
+		end
+		thread.sleep(0.05)  -- Sleep for 50 ms between creations
+	end
+end
+
+
+
+
+
+--- Collects garbage several times, with pauses in between
+function thrCollectGarbage()
+	for i = 1, 20 do
+		collectgarbage("collect")
+		thread.sleep(0.03)  -- Sleep for 30 ms between GC runs
+	end
+end
+
+
+
+
+
+-- Do both object creation and garbage collection in parallel, each in a separate thread:
+local thread1 = thread.new(thrCreateObjects)
+local thread2 = thread.new(thrCollectGarbage)
+
+
+-- Wait for the threads to finish running
+thread1:join()
+thread2:join()
+
+print("Successfully finished.")


### PR DESCRIPTION
Uh oh. This thing crashes.

I had a feeling that the multithreading was too good to be true. Once you start throwing garbace collection into the threads, it comes crashing down. And since Lua may call into the GC at any time, no code is safe from the crash.