### PR TITLE
Added the MultiThreadedStrings test that fails.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,6 +43,7 @@ set(TESTS
 	CurrentThreadId.lua
 	HelloThread.lua
 	HelloWorld.lua
+	MultiThreadedStrings.lua
 	MutexGc.lua
 	NestedThreadCreation.lua
 	RaceCondition.lua

--- a/tests/MultiThreadedStrings.lua
+++ b/tests/MultiThreadedStrings.lua
@@ -1,0 +1,41 @@
+-- Tests creating many strings in parallel
+-- The assumption is that since Lua internalizes strings (stores values only once, references strings by-hash),
+-- it doesn't like multithreading
+
+local thread = require("thread")
+
+
+
+
+--- Creates lots of local temporary strings
+local function thrCreateStrings()
+	for j = 1, 10 do
+		-- print("thread ", thread.currentid(), ", j = ", j)
+		for i = 1, 100 do
+			table.concat({"a", i}, ", ")  -- Create a table, then a string, and lose all references to them immediately
+		end
+		thread.sleep(0.05)  -- Sleep for 50 ms between creations
+	end
+end
+
+
+
+
+
+-- Disable GC altogether, so that it doesn't interfere:
+collectgarbage("stop")
+
+
+-- Start multiple threads doing practically the same thing:
+local threads = {}
+for i = 1, 8 do
+	threads[i] = thread.new(thrCreateStrings)
+end
+
+
+-- Wait for the threads to finish running
+for i = 1, 8 do
+	threads[i]:join()
+end
+
+print("Successfully finished.")


### PR DESCRIPTION
The test crashes, busy-locks or succeeds randomly.

Since Lua internalizes strings in a single table for the entire state, working with strings is an unsafe operation in a multithreaded environment.